### PR TITLE
Terminal Logging with Timestamp | Settings Manager Bug fix

### DIFF
--- a/rem-iot/lib/settings/settings.hpp
+++ b/rem-iot/lib/settings/settings.hpp
@@ -21,6 +21,12 @@
 // This is the length of a single setting in characters. 
 #define SETTING_LEN 40
 
+// The amount of time to wait for the mutex to be available before returning
+#define SETTING_MUTEX_TIMEOUT pdMS_TO_TICKS(10) // 10ms 
+
+// The amount of characters needed for each of the settings, their names, and some formating character (4)
+#define SETTINGS_PRINT_LEN SETTING_LEN * (SETTING_QUANTITY + 4) + 2 + strlen(SSID_ID) + strlen(PASSWORD_ID) + strlen(MQTT_SERVER_ID) + strlen(DEVICE_ID_ID) + strlen(DATA_TOPIC_ID) + strlen(STATUS_TOPIC_ID)
+
 // The total amount of settings that are stored in the EEPROM. This is used for
 // verifying the amount of memory needed for concatenating all of the settings objects
 // into a single buffer.

--- a/rem-iot/lib/settings/settings_manager.cpp
+++ b/rem-iot/lib/settings/settings_manager.cpp
@@ -3,8 +3,6 @@
 #include "EEPROM.h"
 #include "Arduino.h"
 
-#define SETTING_MUTEX_TIMEOUT pdMS_TO_TICKS(10) // 10ms 
-
 SettingsManager::SettingsManager(Terminal * terminal, EEPROMClass * eeprom) {
     this->terminal = terminal;
     this->eeprom = eeprom;
@@ -49,10 +47,9 @@ const char * SettingsManager::getSetting(const char * name) {
 bool SettingsManager::printSettings(char * buf, size_t len) {
     // Calculate the amount of characters needed for each of the settings, their names, and some formating character (4)
     // Like :, ' ', and \r\n for each character as well as before the first string.
-    size_t minLen = SETTING_LEN * (SETTING_QUANTITY + 4) + 2 + strlen(SSID_ID) + strlen(PASSWORD_ID) + strlen(MQTT_SERVER_ID) + strlen(DEVICE_ID_ID) + strlen(DATA_TOPIC_ID) + strlen(STATUS_TOPIC_ID);
-
-    if (len < minLen) {
-        Serial.printf("Minlen %d, len %d\n", minLen, len);
+    
+    if (len < SETTINGS_PRINT_LEN) {
+        Serial.printf("Minlen %d, len %d\n", SETTINGS_PRINT_LEN, len);
         return false;
     }
 

--- a/rem-iot/lib/settings/settings_manager.hpp
+++ b/rem-iot/lib/settings/settings_manager.hpp
@@ -40,7 +40,7 @@ class SettingsManager {
 
         /**
          * @brief Format the setting data into a printable format and place the data 
-         * into the passed buffer
+         * into the passed buffer, the length of the buffer must be at least SETTINGS_PRINT_LEN
          * 
          * @param buf the buffer to write the settings to
          * @param len the length of the buffer

--- a/rem-iot/lib/terminal/terminal.hpp
+++ b/rem-iot/lib/terminal/terminal.hpp
@@ -7,6 +7,9 @@
 
 #define TERMINAL_TIMEOUT_TICK pdMS_TO_TICKS(10)
 
+// The max lenght of the time buffer we would allow
+#define TIME_BUFFER_SIZE_MAX 128
+
 // First argument is the command that was run, the rest are the space dellimited arguments
 typedef int (*commandFunc)(int, char*);
 
@@ -14,17 +17,20 @@ class Terminal {
     
     public:
         Terminal(bool init, Stream * terminalStream);
-        
+
         // Print functions
         void debugln(const char[]);
         void debugln(String str);
         void debug(const char[]);
         void debug(String str);
+        size_t debugf(const char * format, ...)  __attribute__ ((format (printf, 2, 3)));
 
+        // Debug setter and getter
         bool toggleDebug();
-
-        // Debug getter
         bool isDebug();
+
+        // Util for getting time
+        size_t getTime(char * buf);
 
         // Task handler for the terminal
         void handleCharacter();

--- a/rem-iot/lib/wifi-controller/wifi_controller.cpp
+++ b/rem-iot/lib/wifi-controller/wifi_controller.cpp
@@ -50,13 +50,13 @@ bool WiFiController::setupWiFi() {
 
     // Grab the ssid and password from the settings manager, if they aren't there 
     // that means they haven't been stored yet.  
-    const char * wifissid = this->settingsManager->getSetting(PASSWORD_ID);
+    const char * wifissid = this->settingsManager->getSetting(SSID_ID);
     if (wifissid == NULL) {
         this->terminal->debugln("Failed to get the SSID from the settings manager");
         return false;
     }
 
-    const char * wifipass = this->settingsManager->getSetting(SSID_ID);
+    const char * wifipass = this->settingsManager->getSetting(PASSWORD_ID);
     if (wifipass == NULL) {
         this->terminal->debugln("Failed to get the password from the settings manager");
         return false;

--- a/rem-iot/lib/wifi-controller/wifi_controller.cpp
+++ b/rem-iot/lib/wifi-controller/wifi_controller.cpp
@@ -64,11 +64,10 @@ bool WiFiController::setupWiFi() {
 
     // Try and connect to the WiFi, to verify a connection happend we have to 
     // poll the WiFi::status().
-    wl_status_t wifi_status = this->wifi->begin(wifissid, wifissid);
+    wl_status_t wifi_status = this->wifi->begin(wifissid, wifipass);
     do {
         wifi_status = this->wifi->status();
-        this->terminal->debug("WiFi Connection String: ");
-        this->terminal->debugln(wifi_status == WL_CONNECTED ? "Connected" : "Not Connected");
+        this->terminal->debugf("WiFi Connection String: %s\r\n", wifi_status == WL_CONNECTED ? "Connected" : "Not Connected");
         delay(1000);
 
     } while (wifi_status != WL_CONNECTED);

--- a/rem-iot/src/main.cpp
+++ b/rem-iot/src/main.cpp
@@ -133,6 +133,8 @@ void setupPubSubClient() {
     terminal->debugln("Failed to connect to MQTT server, retrying...");
     delay(1000);
   }
+
+  Serial.println("Connected to MQTT server");
 }
 
 void setup() {

--- a/rem-iot/src/main.cpp
+++ b/rem-iot/src/main.cpp
@@ -80,7 +80,6 @@ static const CLI_Command_Definition_t xWiFIStatusCommand = {
     "\r\nwifi-status: \r\n Returns the wifi connected status\r\n",
     prvWiFiStatusCommand, 0 };
 
-
 /**
  * Setup the wifi connection and the NTP server. If the clock is not synced
  * with the NTP server, the function will return false


### PR DESCRIPTION
## Work Done
- Add a timestamp to the logs for logging after the SNTP connection has been established and the time has been synced.
- Bugfix for the network manager code where ssid and password were being used for the other thing during initialization. 